### PR TITLE
Git LFS Cache

### DIFF
--- a/.github/workflows/py_action.yml
+++ b/.github/workflows/py_action.yml
@@ -11,6 +11,8 @@ jobs:
         python-version: ["3.7"]
 
     steps:
+      - name: Checkout code
+        uses: nschloe/action-cached-lfs-checkout@v1
       - uses: actions/checkout@v3
         with:
           lfs: true


### PR DESCRIPTION
Shouldve been included in previous pull requests, but is pretty urgent so GitHub actions wont spend 200mb each time it runs an automated test.