### PR TITLE
Upgrade to python3.8

### DIFF
--- a/.github/workflows/py_action.yml
+++ b/.github/workflows/py_action.yml
@@ -8,18 +8,23 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7"]
+        python-version: [ "3.8" ]
 
     steps:
       - name: Checkout code
         uses: nschloe/action-cached-lfs-checkout@v1
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+      - name: Set up python
+        uses: actions/setup-python@v4.5.0
         with:
           python-version: ${{ matrix.python-version }}
-          cache: "pip"
-          cache-dependency-path: '**/requirements.txt'
-      - name: Install dependencies
+      - name: Cache dependencies
+        uses: actions/cache@v3.2.4
+        id: cache
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}
+      - name: Install pip dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
         run: pip install -r requirements.txt
       - name: Test with pytest
         run: |

--- a/core/data/feature.py
+++ b/core/data/feature.py
@@ -10,6 +10,7 @@ from core.util.util import setup_log
 
 FTS = ['sift', 'lbp', 'glcm']
 
+
 class FeatureExtractor(Logable):
     def __init__(self,
                  img_dir_path=IMGDIR_PATH,
@@ -140,6 +141,7 @@ class FeatureExtractor(Logable):
         @param dir_path: path to species folder
         @param degrees: list of strings, include "rotate" to rotate, "flip" to flip, "all" is default for both
         """
+
         for sub_dir in os.walk(dir_path):
             for image_name in sub_dir[2]:
                 if "all" == degrees:
@@ -152,7 +154,6 @@ class FeatureExtractor(Logable):
                         FeatureExtractor.rotate_and_save_image(sub_dir[0], image_name, i * 90)
                 elif "flip" == degrees:
                     FeatureExtractor.flip_and_save_image(sub_dir[0], image_name)
-
 
     @staticmethod
     def rotate_and_save_image(img_path: str, name: str, degree: int):

--- a/core/run.py
+++ b/core/run.py
@@ -1,16 +1,12 @@
-import os
-import sys
 
 from core.data.fetch import fetch_images, setup_dataset
 from core.util.constants import RAW_DATA_PATH, RAW_LABEL_PATH, DATASET_PATH, LABEL_DATASET_PATH, IMGDIR_PATH
 from core.data.feature import FeatureExtractor
 from core.model.model import Model
-
+from util.pysetup import PySetup
 
 if __name__ == "__main__":
-    sys.path.append(f"{os.getcwd()}{os.sep}core")
-    if not os.getcwd().split(os.sep)[-1] == "core":
-        os.chdir("core")
+    ops = PySetup()
     df = setup_dataset(raw_dataset_path=RAW_DATA_PATH,
                        raw_label_path=RAW_LABEL_PATH,
                        label_dataset_path=LABEL_DATASET_PATH,

--- a/core/util/pysetup.py
+++ b/core/util/pysetup.py
@@ -1,0 +1,29 @@
+import os
+import sys
+
+from util.logging.logable import Logable
+
+
+class PySetup(Logable):
+    def __init__(self,
+                 major_version=3,
+                 minor_version=8,
+                 micro_version=18,
+                 cwd="core"):
+        super().__init__()
+        self.cwd = cwd
+        self.version = (major_version, minor_version, micro_version)
+        self._check_py_version()
+        self._append_cwd()
+
+    def _check_py_version(self):
+        def pretty_version(y): return '.'.join(list(tuple(map(lambda x: str(x), y))))
+
+        if sys.version_info[:3] != self.version:
+            raise ImportError(f"Required Python version: {pretty_version(sys.version_info[:3])}\n"
+                              f"Current version: {pretty_version(self.version[:3])}")
+
+    def _append_cwd(self):
+        sys.path.append(f"{os.getcwd()}{os.sep}{self.cwd}")
+        if not os.getcwd().split("/")[-1] == self.cwd:
+            os.chdir(self.cwd)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,10 @@
-
 requests==2.31.0
 pillow==9.5.0
 pandas==1.3.5
 pytest==7.4.2
 ruff==0.0.290
 scikit-image==0.19.3
-tensorflow==2.11.0
+tensorflow==2.13.1
 matplotlib==3.5.3
 roboflow==1.1.6
 ultralytics==8.0.134


### PR DESCRIPTION
RTX3060 requires nvidia-drivers-525, which require CUDA >11.2, which requires Tensorflow >2.13.0 which requires >python3.8

