### PR TITLE
Resize when yolo-cropping

### DIFF
--- a/core/data/fetch.py
+++ b/core/data/fetch.py
@@ -131,8 +131,13 @@ class Database(Logable):
                     self.error(f"Unknown error: {e}")
                     raise e
             else:
+                model = YOLO('yolo/medium250e.pt')
+                res = obj_det(Image.fromarray(np.load(path, allow_pickle=True)), model, conf=0.25, img_size=(640, 640))
+                xywhn = res[0].boxes.xywhn
+                if xywhn.numel() > 0:
+                    accepted = True
                 out = path
-                accepted = True
+                self.debug(out)
             return out, accepted
 
         with ThreadPoolExecutor(50) as executor:

--- a/core/data/fetch.py
+++ b/core/data/fetch.py
@@ -12,13 +12,14 @@ from ultralytics import YOLO
 import urllib3
 
 from core.util.logging.logable import Logable
-from core.util.util import timing, setup_log, log_ent_exit
+from core.util.util import timing, setup_log, log_ent_exit, ConstantSingleton
 from core.util.constants import (IMGDIR_PATH, MERGE_COLS, BFLY_FAMILY, BFLY_LIFESTAGE, DATASET_PATH, DIRNAME_DELIM,
-                                 RAW_WORLD_DATA_PATH, RAW_WORLD_LABEL_PATH, IMG_SIZE)
+                                 RAW_WORLD_DATA_PATH, RAW_WORLD_LABEL_PATH)
 from core.data.feature import FeatureExtractor
 from core.yolo.yolo_func import obj_det, yolo_crop
 
 urllib3.disable_warnings(category=urllib3.exceptions.InsecureRequestWarning)
+constants = ConstantSingleton()
 
 
 class Database(Logable):
@@ -166,7 +167,7 @@ class Database(Logable):
                             img = yolo_crop(img, xywhn)
                             accepted = True
                     img = FeatureExtractor.make_square_with_bb(img)
-                    img = img.resize((IMG_SIZE, IMG_SIZE))
+                    img = img.resize((constants['IMG_SIZE'], constants['IMG_SIZE']))
                     img = np.asarray(img)
                     np.save(path, img, allow_pickle=True)
                     out = path

--- a/core/data/fetch.py
+++ b/core/data/fetch.py
@@ -9,7 +9,6 @@ import pandas as pd
 import os
 from PIL import Image
 from ultralytics import YOLO
-from urllib3.exceptions import InsecureRequestWarning
 import urllib3
 
 from core.util.logging.logable import Logable
@@ -18,7 +17,7 @@ from core.util.constants import IMGDIR_PATH, MERGE_COLS, BFLY_FAMILY, BFLY_LIFES
 from core.data.feature import FeatureExtractor
 from yolo import obj_det, yolo_crop
 
-urllib3.disable_warnings(category=InsecureRequestWarning)
+urllib3.disable_warnings(category=urllib3.exceptions.InsecureRequestWarning)
 
 
 class Database(Logable):

--- a/core/model/model.py
+++ b/core/model/model.py
@@ -1,21 +1,21 @@
 import datetime
 from pprint import pprint
 import os
-import json
 
 import tensorflow as tf
 import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt
 
-from core.util.constants import FULL_MODEL_CHECKPOINT_PATH
 from core.util.logging.logable import Logable
 from core.data.feature import FeatureExtractor
 from sklearn import preprocessing
 
+from core.util.util import ConstantSingleton
 
-with open('core/util/constants.txt', 'r') as f:
-    constants = json.load(f)
+constants = ConstantSingleton()
+
+
 class Model(Logable):
     def __init__(self,
                  df: pd.DataFrame,

--- a/core/model/model.py
+++ b/core/model/model.py
@@ -114,12 +114,12 @@ class Model(Logable):
         remaining_dataset = self.dataset.skip(train_size)
         self.val_dataset = remaining_dataset.take(val_size)
         self.test_dataset = remaining_dataset.skip(val_size)
-        self.train_dataset = self.train_dataset.batch(32).shuffle(reshuffle_each_iteration=True,
-                                                                  buffer_size=len(self.df[self.feature]))
-        self.val_dataset = self.val_dataset.batch(32).shuffle(reshuffle_each_iteration=True,
-                                                              buffer_size=len(self.df[self.feature]))
-        self.test_dataset = self.test_dataset.batch(32).shuffle(reshuffle_each_iteration=True,
-                                                                buffer_size=len(self.df[self.feature]))
+        self.train_dataset = self.train_dataset.shuffle(reshuffle_each_iteration=True,
+                                                        buffer_size=len(self.df[self.feature])).batch(32)
+        self.val_dataset = self.val_dataset.shuffle(reshuffle_each_iteration=True,
+                                                    buffer_size=len(self.df[self.feature])).batch(32)
+        self.test_dataset = self.test_dataset.shuffle(reshuffle_each_iteration=True,
+                                                      buffer_size=len(self.df[self.feature])).batch(32)
 
     def compile(self, lr=0.001):
         custom_optimizer = tf.keras.optimizers.Adam(learning_rate=lr)

--- a/core/run.py
+++ b/core/run.py
@@ -1,32 +1,14 @@
 import logging
-import json
 
 from core.data.fetch import Database
 from core.util.constants import RAW_DATA_PATH, RAW_LABEL_PATH, DATASET_PATH, LABEL_DATASET_PATH, IMGDIR_PATH
 from core.data.feature import FeatureExtractor
 from core.model.model import Model
 from core.util.pysetup import PySetup
-from core.util.util import setup_argparse
+from core.util.util import ConstantSingleton
 
 if __name__ == "__main__":
-    args = setup_argparse()
-    if args is not None:
-        json_constants = {
-            "MODEL_ID": args.MODEL_ID,
-            "KERNEL_SIZE": args.KERNEL_SIZE,
-            "LEARNING_RATE": args.LEARNING_RATE,
-            "NUM_EPOCHS": args.NUM_EPOCHS,
-            "NUM_IMAGES": args.NUM_IMAGES,
-            "IMG_SIZE": args.IMG_SIZE,
-            "CROPPED": args.CROPPED
-        }
-        with open('core/util/constants.txt', 'w') as f:
-            json.dump(json_constants, f)
-
-    with open('core/util/constants.txt', 'r') as f:
-        constants = json.load(f)
-
-
+    constants = ConstantSingleton()
     ops = PySetup()
     num_rows = constants["NUM_IMAGES"]
     feature = ""
@@ -44,7 +26,6 @@ if __name__ == "__main__":
                   bfly=["all"])
     df = db.setup_dataset()
     df = ft_extractor.pre_process(df, feature, radius=2)
-
     df = db.only_accepted(df)
     model = Model(df, IMGDIR_PATH, feature=feature, kernel_size=(constants["KERNEL_SIZE"], constants["KERNEL_SIZE"]))
     # model.load()

--- a/core/util/util.py
+++ b/core/util/util.py
@@ -49,6 +49,7 @@ def setup_log(log_level):
     logger_file.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
     logging.getLogger().addHandler(logger_file)
     logging.getLogger().addFilter(LogFilter())
+    logging.getLogger().setLevel(logging.INFO)
 
 
 class LogFilter(logging.Filter):

--- a/core/util/util.py
+++ b/core/util/util.py
@@ -6,6 +6,63 @@ from logging.handlers import TimedRotatingFileHandler
 from time import time
 import logging
 import argparse
+import json
+
+
+class ConstantSingleton(object):
+    _instance = None
+
+    def __init__(self):
+        super().__init__()
+        self.args = self._setup_argparse()
+        self.constants = self._setup_constants()
+
+    def __new__(cls):
+        if not hasattr(cls, 'instance'):
+            cls._instance = super(ConstantSingleton, cls).__new__(cls)
+        return cls._instance
+
+    def __getitem__(self, key):
+        return self.constants[key]
+
+    def _setup_constants(self):
+        if self.args is not None:
+            json_constants = {
+                "MODEL_ID": self.args.MODEL_ID,
+                "KERNEL_SIZE": self.args.KERNEL_SIZE,
+                "LEARNING_RATE": self.args.LEARNING_RATE,
+                "NUM_EPOCHS": self.args.NUM_EPOCHS,
+                "NUM_IMAGES": self.args.NUM_IMAGES,
+                "IMG_SIZE": self.args.IMG_SIZE,
+                "CROPPED": self.args.CROPPED
+            }
+            with open('constants.txt', 'w') as f:
+                print(os.getcwd())
+                json.dump(json_constants, f)
+
+        with open('constants.txt', 'r') as f:
+            constants = json.load(f)
+        return constants
+
+    @staticmethod
+    def _setup_argparse() -> Namespace:
+        parser = argparse.ArgumentParser(
+            description='MODEL_ID, KERNEL_SIZE, LEARNING_RATE, NUM_EPOCHS, NUM_IMAGES, IMG_SIZE, CROPPED')
+        parser.add_argument('MODEL_ID', metavar='ID', type=int,
+                            help='an integer for model id')
+        parser.add_argument('KERNEL_SIZE', metavar='Kernel', type=int,
+                            help='an integer N for kernel size (N, N)')
+        parser.add_argument('LEARNING_RATE', metavar='LearningRate', type=float,
+                            help='a float for learning rate')
+        parser.add_argument('NUM_EPOCHS', metavar='Epochs', type=int,
+                            help='an integer for amount of epochs')
+        parser.add_argument('NUM_IMAGES', metavar='ImageAmount', type=int,
+                            help='an integer for amount of images')
+        parser.add_argument('IMG_SIZE', metavar='ImageSize', type=int,
+                            help='an integer N for size of images N x N')
+        parser.add_argument('CROPPED', metavar='Cropped', type=int,
+                            help='crop images with YOLO model (0=false, 1=true)')
+        return parser.parse_args()
 
 
 def timing(f):
@@ -52,26 +109,6 @@ def setup_log(log_level):
     logging.getLogger().addHandler(logger_file)
     logging.getLogger().addFilter(LogFilter())
     logging.getLogger().setLevel(logging.INFO)
-
-
-def setup_argparse() -> Namespace:
-    parser = argparse.ArgumentParser(
-        description='MODEL_ID, KERNEL_SIZE, LEARNING_RATE, NUM_EPOCHS, NUM_IMAGES, IMG_SIZE, CROPPED')
-    parser.add_argument('MODEL_ID', metavar='ID', type=int,
-                        help='an integer for model id')
-    parser.add_argument('KERNEL_SIZE', metavar='Kernel', type=int,
-                        help='an integer N for kernel size (N, N)')
-    parser.add_argument('LEARNING_RATE', metavar='LearningRate', type=float,
-                        help='a float for learning rate')
-    parser.add_argument('NUM_EPOCHS', metavar='Epochs', type=int,
-                        help='an integer for amount of epochs')
-    parser.add_argument('NUM_IMAGES', metavar='ImageAmount', type=int,
-                        help='an integer for amount of images')
-    parser.add_argument('IMG_SIZE', metavar='ImageSize', type=int,
-                        help='an integer N for size of images N x N')
-    parser.add_argument('CROPPED', metavar='Cropped', type=int,
-                        help='crop images with YOLO model (0=false, 1=true)')
-    return parser.parse_args()
 
 
 class LogFilter(logging.Filter):

--- a/core/yolo/yolo_func.py
+++ b/core/yolo/yolo_func.py
@@ -1,9 +1,12 @@
 from typing import Tuple
 from ultralytics import YOLO
+from PIL import Image
+
+Image.MAX_IMAGE_PIXELS = None
 
 
-def obj_det(img, model: YOLO, conf=0.25):
-    res = model.predict(source=img, save=False, save_txt=False, imgsz=640, conf=conf, device="cpu")
+def obj_det(img, model: YOLO, conf=0.25, img_size=(640, 640)):
+    res = model.predict(source=img, save=False, save_txt=False, imgsz=img_size, conf=conf, device="cpu")
     return res
 
 
@@ -15,19 +18,18 @@ def load_img(img, xywhn) -> Tuple[float, float, float, float]:
     label_width = float(xywhn[0][2])
     label_height = float(xywhn[0][3])
 
-    label_enlarge = 1.10
-
-    left = img_width * (x_coordinate - label_width / 2 * label_enlarge)
-    top = img_height * (y_coordinate - label_height / 2 * label_enlarge)
-    right = img_width * (x_coordinate + label_width / 2 * label_enlarge)
-    bottom = img_height * (y_coordinate + label_height / 2 * label_enlarge)
+    left = img_width * (x_coordinate - label_width / 2)
+    top = img_height * (y_coordinate - label_height / 2)
+    right = img_width * (x_coordinate + label_width / 2)
+    bottom = img_height * (y_coordinate + label_height / 2)
 
     fcorners = (left, top, right, bottom)
 
     return fcorners
 
 
-def yolo_crop(img, xywhn):
+def yolo_crop(img: Image.Image, xywhn, rs_size=(416, 416)):
     corners = load_img(img, xywhn)
     img1 = img.crop(corners)
+    img1 = img1.resize(rs_size, resample=3)
     return img1


### PR DESCRIPTION
Resize images when yolo-cropping to avoid black bars which will screw with extracted features. Some images will be stretched but still generates better performance (25% to 32% on 6000 images 50 epochs).
![image](https://github.com/DAT-05-02/P5/assets/32768178/768b85da-9936-47aa-b6df-33c2744d9f77)
