### PR TITLE
Fetch by num species/images

### DIFF
--- a/core/data/feature.py
+++ b/core/data/feature.py
@@ -99,15 +99,6 @@ class FeatureExtractor(Logable):
             out_ft = feature
         return f"{self.save_path}{DIRNAME_DELIM}{out_ft}/"
 
-    def _mk_ft_dirs(self):
-        """Creates dirs for each available feature
-        @return: None
-        """
-        for feature in FTS:
-            dir_new = self.dirpath_from_ft(feature)
-            if not os.path.exists(dir_new):
-                os.makedirs(dir_new)
-
     @staticmethod
     def lbp(img: np.ndarray, method="ror", radius=1):
         """Create Local Binary Pattern for an image

--- a/core/data/feature.py
+++ b/core/data/feature.py
@@ -289,7 +289,8 @@ class FeatureExtractor(Logable):
                 img = np.load(f)
                 output_shape = img.shape
                 if output_shape not in unique_output_shapes:
-                    print("unique shape: ", output_shape)
+                    self.info("unique shape: ", output_shape)
+                    self.info(f"at path: {path}")
                     unique_output_shapes.add(output_shape)
 
         if len(unique_output_shapes) > 1:

--- a/core/data/feature.py
+++ b/core/data/feature.py
@@ -23,7 +23,6 @@ class FeatureExtractor(Logable):
         setup_log(log_level=log_level)
         self.save_path = feature_dir_path
         self.img_path = img_dir_path
-        self._mk_ft_dirs()
 
     def pre_process(self,
                     df: pd.DataFrame,

--- a/core/data/feature.py
+++ b/core/data/feature.py
@@ -289,7 +289,7 @@ class FeatureExtractor(Logable):
                 img = np.load(f)
                 output_shape = img.shape
                 if output_shape not in unique_output_shapes:
-                    self.info("unique shape: ", output_shape)
+                    self.info(f"unique shape: {output_shape}")
                     self.info(f"at path: {path}")
                     unique_output_shapes.add(output_shape)
 

--- a/core/data/feature.py
+++ b/core/data/feature.py
@@ -276,13 +276,14 @@ class FeatureExtractor(Logable):
                 raise e
 
     @log_ent_exit
-    def shape_from_feature(self, df, feature='path', ):
+    def shape_from_feature(self, df, feature='path'):
         """Aggregate shape, depending on which feature should be trained on.
         @param df: dataframe
         @param feature: which feature to check shape of
         @raise ValueError: if not all extracted features are of same shape
         @return: shape of feature
         """
+        feature = 'path' if feature == '' else feature
         paths = df[feature]
         unique_output_shapes = set()
 

--- a/core/data/feature.py
+++ b/core/data/feature.py
@@ -75,8 +75,12 @@ class FeatureExtractor(Logable):
         @param feature: name of feature folder
         @return: parent feature path + label path
         """
-        l_name = str(row['path']).split(PATH_SEP)[-2]
-        return self.dirpath_from_ft(feature) + l_name + PATH_SEP
+        try:
+            l_name = str(row['path']).split(PATH_SEP)[-2]
+            return self.dirpath_from_ft(feature) + l_name + PATH_SEP
+        except IndexError as e:
+            self.error(f"row: {row}", stack_info=True, exc_info=True)
+            raise e
 
     @log_ent_exit
     def path_from_row_ft(self, row: pd.Series, feature: str):
@@ -85,8 +89,12 @@ class FeatureExtractor(Logable):
         @param feature: name of feature folder
         @return: full file path
         """
-        f_name = str(row['path']).split(PATH_SEP)[-1].split('.')[0] + ".npy"
-        return self.l_dirpath_from_row(row, feature) + f_name
+        try:
+            f_name = str(row['path']).split(PATH_SEP)[-1].split('.')[0] + ".npy"
+            return self.l_dirpath_from_row(row, feature) + f_name
+        except IndexError as e:
+            self.error(f"row: {row}", stack_info=True, exc_info=True)
+            raise e
 
     def dirpath_from_ft(self, feature):
         """Outermost parent directory based on feature.

--- a/core/data/fetch.py
+++ b/core/data/fetch.py
@@ -267,10 +267,17 @@ class Database(Logable):
         @return: df if compliant, otherwise None
         """
         if os.path.exists(self.dataset_csv_filename):
-            df = pd.read_csv(self.dataset_csv_filename, low_memory=False)
-            self.info(f"len(df): {len(df)}, self.num_rows: {self.num_rows}")
-            if self._num_rows and len(df) == self.num_rows:
-                return True
+            db = pd.read_csv(self.dataset_csv_filename, low_memory=False)
+            df = self._get_working_df(db)
+            try:
+                if df['path'].isnull().values.any():
+                    return False
+                if self.crop == 1 and df['yolo_accepted'].isnull().values.any():
+                    return False
+                if self._num_rows and len(df) == self.num_rows:
+                    return True
+            except KeyError:
+                return False
         return False
 
     def _partial_df(self) -> bool:

--- a/core/data/fetch.py
+++ b/core/data/fetch.py
@@ -80,7 +80,6 @@ class Database(Logable):
             """Case if current num images/species fits with results. Basically just returns the working window"""
             db = pd.read_csv(self.dataset_csv_filename, low_memory=False)
             df = self._get_working_df(db)
-            df.dropna(subset=['path'], inplace=True)
             self.info(db.shape)
             self.info(df.shape)
             return db, df
@@ -96,6 +95,7 @@ class Database(Logable):
             """Case if we are starting from fresh"""
             db, df_label = self._make_dfs_from_raws()
             db = self._merge_dfs_on_gbif(db, df_label)
+            db.dropna(subset=[self.link_col, 'species'])
             db = self.pad_dataset(db, RAW_WORLD_DATA_PATH, RAW_WORLD_LABEL_PATH, self.num_images)
             db = db.reset_index(drop=True)
 
@@ -104,7 +104,6 @@ class Database(Logable):
         # update db rows with newly acquired information
         db.update(df)
         db.to_csv(self.dataset_csv_filename, index=False)
-        df = df.dropna(subset=['path'])
         df = df.loc[~df['path'].isin(ERR_VALUES)]
         self.info(db.shape)
         self.info(df.shape)

--- a/core/data/fetch.py
+++ b/core/data/fetch.py
@@ -168,6 +168,7 @@ class Database(Logable):
                             accepted = True
                     img = FeatureExtractor.make_square_with_bb(img)
                     img = img.resize((constants['IMG_SIZE'], constants['IMG_SIZE']))
+                    img = img.convert("RGB")
                     img = np.asarray(img)
                     np.save(path, img, allow_pickle=True)
                     out = path

--- a/core/data/fetch.py
+++ b/core/data/fetch.py
@@ -307,16 +307,16 @@ class Database(Logable):
         self.info(f'df shape: {df.shape}')
         return df
 
-    def _sort_drop_rows(self, df: pd.DataFrame):
-        """If self is initialized with sort, sort species. If self has num_rows, drop rest of rows.
+    def _get_working_df(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Get current working window in db based on num species/images
         @param df: dataframe
         @return resulting dataframe after sort/drop"""
-        if self.sort:
-            df.sort_values(by=['species'], inplace=True)
         self.info(f"found {len(df['species'].unique())} unique species")
-        if self._num_rows:
-            df.drop(df.index[self._num_rows:], inplace=True)
-        df.reset_index(inplace=True, drop=True)
+        if self.num_images and self.num_species:
+            species = df['species'].unique()[:self.num_species]
+            df = df.loc[df['species'].isin(species)].groupby('species').head(self.num_images)
+        else:
+            df = df.loc[df['species']].groupby('species').head(self.num_images)
         return df
 
     def _make_dfs_from_raws(self):

--- a/core/data/fetch.py
+++ b/core/data/fetch.py
@@ -14,7 +14,7 @@ import urllib3
 
 from core.util.logging.logable import Logable
 from core.util.util import timing, setup_log, log_ent_exit, ConstantSingleton
-from core.util.constants import (IMGDIR_PATH, MERGE_COLS, BFLY_FAMILY, BFLY_LIFESTAGE, DATASET_PATH, DIRNAME_DELIM,
+from core.util.constants import (IMGDIR_PATH, MERGE_COLS, BFLY_FAMILY, BFLY_LIFESTAGE, DIRNAME_DELIM,
                                  RAW_WORLD_DATA_PATH, RAW_WORLD_LABEL_PATH)
 from core.data.feature import FeatureExtractor
 from core.yolo.yolo_func import obj_det, yolo_crop

--- a/core/data/fetch.py
+++ b/core/data/fetch.py
@@ -122,14 +122,14 @@ class Database(Logable):
 
             species_with_less_than_optimal_amount_of_images = []
 
-            totalRows = 0
+            total_rows = 0
             for index, count in out.items():
                 if count < min_amount_of_pictures:
                     species_with_less_than_optimal_amount_of_images.append(index)
-                    totalRows += 1
+                    total_rows += 1
 
-            totalRows = totalRows * min_amount_of_pictures
-            print("Total number of extra rows: ", totalRows)
+            total_rows = total_rows * min_amount_of_pictures
+            print("Total number of extra rows: ", total_rows)
             world_df = world_df.loc[world_df['species'].isin(species_with_less_than_optimal_amount_of_images)]
             # loop that gets the species, which are below the required amount
             for item, count in less_than_list:

--- a/core/data/fetch.py
+++ b/core/data/fetch.py
@@ -346,8 +346,9 @@ class Database(Logable):
 
     @log_ent_exit
     def only_accepted(self, df) -> pd.DataFrame:
-        df = df.loc[df['yolo_accepted'].isin(['True', True])]
-        self.info(f"{len(df)} yolo_accepted")
+        if constants['CROPPED'] == 1:
+            df = df.loc[df['yolo_accepted'].isin(['True', True])]
+            self.info(f"{len(df)} yolo_accepted")
         return df
 
     @staticmethod

--- a/core/data/fetch.py
+++ b/core/data/fetch.py
@@ -372,9 +372,9 @@ class Database(Logable):
         if self._num_rows is None:
             return None
         elif self.degrees == "all":
-            return self._num_rows * 8
+            return self.num_images * self.num_species * 8
         elif self.degrees == "flip":
-            return self._num_rows * 2
+            return self.num_images * self.num_species * 2
         elif self.degrees == "rotate":
-            return self._num_rows * 4
-        return self._num_rows
+            return self.num_images * self.num_species * 4
+        return self.num_images * self.num_species

--- a/core/data/fetch.py
+++ b/core/data/fetch.py
@@ -197,7 +197,7 @@ class Database(Logable):
                     self.warning(f"Timeout occurred for index {index}")
                     return "TIMEOUT", False
                 except requests.exceptions.RequestException as e:
-                    self.warning(f"Error occurred: {e}")
+                    self.warning(f"Error occurred: {e} at index {index}")
                     return "REQUESTEXCEPTION", False
                 except urllib3.exceptions.ReadTimeoutError:
                     self.warning(f"Read timed out on {index}")

--- a/core/data/fetch.py
+++ b/core/data/fetch.py
@@ -35,10 +35,9 @@ class Database(Logable):
                  ft_extractor: FeatureExtractor,
                  degrees: str,
                  link_col="identifier",
-                 num_rows=None,
                  crop=True,
-                 minimum_images=None,
-                 sort=False,
+                 num_species=None,
+                 num_images=None,
                  log_level=logging.INFO):
         """ Database class
             @param raw_label_path: path to original label dataset file
@@ -46,11 +45,10 @@ class Database(Logable):
             @param label_dataset_path: path to label csv file
             @param dataset_csv_filename: filename for the csv file
             @param link_col: name of column containing links
-            @param num_rows: number of rows to include
-            @param sort: if dataset should be sorted by species
+            @param num_images: number of images to include
+            @param num_species: number of species to include
             @param bfly: list of species that is included in dataset, have "all" in list for only butterflies (no moths)
             @param crop: boolean if yolo should run and crop images
-            @param minimum_images: number of minimum images per species, if no minimum put None
             """
         super().__init__()
         setup_log(log_level=log_level)
@@ -60,13 +58,13 @@ class Database(Logable):
         self.dataset_csv_filename = dataset_csv_filename
         self.link_col = link_col
         self.ft_extractor = ft_extractor
+        self.num_species = num_species
+        self.num_images = num_images
         self.bfly = bfly
         self.degrees = degrees
-        self._num_rows = num_rows
+        self._num_rows = num_images
         self.crop = crop
-        self.minimum_images = minimum_images
         self.num_rows = self.num_rows()
-        self.sort = sort
 
     def setup_dataset(self):
         """Constructs dataframe. Makes necessary directories, checks if current .csv file fits with self, and returns

--- a/core/model/model.py
+++ b/core/model/model.py
@@ -49,10 +49,19 @@ class Model(Logable):
 
         return model
 
+    @staticmethod
+    def _data_generator(df):
+        for row in df:
+            arr: np.ndarray = np.asarray(np.load(row, allow_pickle=True)).astype(np.uint8)
+            arr: tf.Tensor = tf.convert_to_tensor(arr, dtype=np.uint8)
+            yield arr
+
     def _setup_dataset(self):
-        # Load arrays and slice to tensors
-        data = np.array(list(map(lambda x: np.load(x, allow_pickle=True), self.df[self.feature])))
-        data = tf.data.Dataset.from_tensor_slices(data)
+        data = tf.data.Dataset.from_generator(
+            generator=self._data_generator,
+            args=[tf.convert_to_tensor(self.df[self.feature].to_numpy())],
+            output_signature=(tf.TensorSpec(shape=self.shape, dtype=np.uint8))
+        )
         # Encode labels from strings to integers, then as tensors
         label_encoder = preprocessing.LabelEncoder()
         self.df['species'] = label_encoder.fit_transform(self.df['species'])
@@ -62,7 +71,7 @@ class Model(Logable):
         self.log.info(data.element_spec)
         self.log.info(label.element_spec)
         self.log.info(f"unique species: {len(self.df['species'].unique())}")
-        # Convert to one-hot tensors, essentially selector matrices with a 1 corresponding to the label index
+        # Convert label to one-hot tensors, essentially selector matrices with a 1 corresponding to the label index
         label = label.map(
             lambda x: tf.one_hot(x, len(self.df['species'].unique())),
             num_parallel_calls=tf.data.AUTOTUNE,
@@ -93,20 +102,27 @@ class Model(Logable):
         self.model = tf.keras.models.load_model(model_path)
 
     def split_dataset(self, validation_split=0.15, test_split=0.15, shuffle=True):
-        val_size = int(validation_split * len(self.dataset))
-        test_size = int(test_split * len(self.dataset))
-        train_size = len(self.dataset) - val_size - test_size
+        _len = len(self.df[self.feature])
+        val_size = int(validation_split * _len)
+        test_size = int(test_split * _len)
+        train_size = _len - val_size - test_size
         self.log.info(self.dataset.element_spec)
         self.train_dataset = self.dataset.take(train_size)
         remaining_dataset = self.dataset.skip(train_size)
         self.val_dataset = remaining_dataset.take(val_size)
         self.test_dataset = remaining_dataset.skip(val_size)
-        self.train_dataset = self.train_dataset.shuffle(reshuffle_each_iteration=True,
-                                                        buffer_size=len(self.df[self.feature])).batch(32)
-        self.val_dataset = self.val_dataset.shuffle(reshuffle_each_iteration=True,
-                                                    buffer_size=len(self.df[self.feature])).batch(32)
-        self.test_dataset = self.test_dataset.shuffle(reshuffle_each_iteration=True,
-                                                      buffer_size=len(self.df[self.feature])).batch(32)
+        self.train_dataset = self.train_dataset.shuffle(
+            reshuffle_each_iteration=True,
+            buffer_size=len(self.df[self.feature])
+        ).batch(32).prefetch(tf.data.AUTOTUNE)
+        self.val_dataset = self.val_dataset.shuffle(
+            reshuffle_each_iteration=True,
+            buffer_size=len(self.df[self.feature])
+        ).batch(32).prefetch(tf.data.AUTOTUNE)
+        self.test_dataset = self.test_dataset.shuffle(
+            reshuffle_each_iteration=True,
+            buffer_size=len(self.df[self.feature])
+        ).batch(32).prefetch(tf.data.AUTOTUNE)
 
     def compile(self, lr=0.001):
         custom_optimizer = tf.keras.optimizers.Adam(learning_rate=lr)

--- a/core/model/model.py
+++ b/core/model/model.py
@@ -49,6 +49,35 @@ class Model(Logable):
 
         return model
 
+    def _create_model2(self, kernel_size=(3, 3)):
+        model = tf.keras.models.Sequential([
+            tf.keras.layers.Conv2D(32, kernel_size, activation="relu", data_format="channels_last",
+                                   input_shape=self.shape),
+            tf.keras.layers.MaxPooling2D((2, 2)),
+            tf.keras.layers.Conv2D(64, kernel_size, activation="relu"),
+            tf.keras.layers.MaxPooling2D((2, 2)),
+            tf.keras.layers.Conv2D(128, kernel_size, activation="relu"),
+            tf.keras.layers.Conv2D(128, kernel_size, activation="relu"),
+            tf.keras.layers.MaxPooling2D((2, 2)),
+            tf.keras.layers.Conv2D(128, kernel_size, activation="relu"),
+            tf.keras.layers.Conv2D(128, kernel_size, activation="relu"),
+            tf.keras.layers.Dropout(0.1),
+            tf.keras.layers.Conv2D(128, kernel_size, activation="relu"),
+            tf.keras.layers.Conv2D(128, kernel_size, activation="relu"),
+            tf.keras.layers.MaxPooling2D((2, 2)),
+            tf.keras.layers.Conv2D(256, kernel_size, activation="relu"),
+            tf.keras.layers.Conv2D(256, kernel_size, activation="relu"),
+            tf.keras.layers.Dropout(0.1),
+            tf.keras.layers.Conv2D(256, kernel_size, activation="relu"),
+            tf.keras.layers.Conv2D(516, kernel_size, activation="relu"),
+            tf.keras.layers.Conv2D(516, kernel_size, activation="relu"),
+            tf.keras.layers.Flatten(),
+            tf.keras.layers.Dense(1032, activation="relu"),
+            tf.keras.layers.Dense(len(self.df['species'].unique()), activation="softmax")
+        ])
+
+        return model
+
     @staticmethod
     def _data_generator(df):
         for row in df:
@@ -115,15 +144,15 @@ class Model(Logable):
         self.train_dataset = self.train_dataset.shuffle(
             reshuffle_each_iteration=True,
             buffer_size=len(self.df[self.feature])
-        ).batch(32).prefetch(tf.data.AUTOTUNE)
+        ).batch(64).prefetch(tf.data.AUTOTUNE)
         self.val_dataset = self.val_dataset.shuffle(
             reshuffle_each_iteration=True,
             buffer_size=len(self.df[self.feature])
-        ).batch(32).prefetch(tf.data.AUTOTUNE)
+        ).batch(64).prefetch(tf.data.AUTOTUNE)
         self.test_dataset = self.test_dataset.shuffle(
             reshuffle_each_iteration=True,
             buffer_size=len(self.df[self.feature])
-        ).batch(32).prefetch(tf.data.AUTOTUNE)
+        ).batch(64).prefetch(tf.data.AUTOTUNE)
 
     def compile(self, lr=0.001):
         custom_optimizer = tf.keras.optimizers.Adam(learning_rate=lr)
@@ -139,7 +168,7 @@ class Model(Logable):
         callbacks = tf.keras.callbacks.TensorBoard(log_dir=log_dir)
 
         history = self.model.fit(
-            self.train_dataset.prefetch(tf.data.AUTOTUNE),
+            self.train_dataset,
             validation_data=self.val_dataset,
             epochs=epochs,
             callbacks=[callbacks]

--- a/core/model/model.py
+++ b/core/model/model.py
@@ -79,6 +79,7 @@ class Model(Logable):
         self.log.info(label)
         # np.arrays and labels to same dataset
         dataset = tf.data.Dataset.zip((data, label))
+        dataset.shuffle(dataset.cardinality())
         return dataset
 
     def print_dataset_info(self):
@@ -129,7 +130,7 @@ class Model(Logable):
         self.model.compile(
             custom_optimizer,
             loss=tf.keras.losses.CategoricalCrossentropy(),
-            metrics=['accuracy']
+            metrics=['accuracy', tf.keras.metrics.Precision()]
         )
 
     def fit(self, epochs=10):

--- a/core/run.py
+++ b/core/run.py
@@ -10,23 +10,25 @@ from core.util.util import ConstantSingleton
 if __name__ == "__main__":
     constants = ConstantSingleton()
     ops = PySetup()
-    num_rows = constants["NUM_IMAGES"]
-    feature = ""
+    num_images = constants['NUM_IMAGES']
+    num_species = constants['NUM_SPECIES']
+    feature = "path"
     ft_extractor = FeatureExtractor(log_level=logging.INFO)
-    db = Database(raw_dataset_path=RAW_DATA_PATH,
-                  raw_label_path=RAW_LABEL_PATH,
-                  label_dataset_path=LABEL_DATASET_PATH,
-                  dataset_csv_filename=DATASET_PATH,
-                  log_level=logging.DEBUG,
-                  ft_extractor=ft_extractor,
-                  num_rows=num_rows,
-                  crop=constants["CROPPED"],
-                  minimum_images=None,
-                  degrees="none",
-                  bfly=["all"])
-    df = db.setup_dataset()
-    df = ft_extractor.pre_process(df, feature, radius=2)
-    df = db.only_accepted(df)
+    database = Database(raw_dataset_path=RAW_DATA_PATH,
+                        raw_label_path=RAW_LABEL_PATH,
+                        label_dataset_path=LABEL_DATASET_PATH,
+                        dataset_csv_filename=DATASET_PATH,
+                        log_level=logging.DEBUG,
+                        ft_extractor=ft_extractor,
+                        num_species=num_species,
+                        num_images=num_images,
+                        crop=constants["CROPPED"],
+                        degrees="none",
+                        bfly=["all"])
+    db, df = database.setup_dataset()
+    print(df.shape)
+    df = ft_extractor.pre_process(db, df, feature, radius=2)
+    df = database.only_accepted(df)
     model = Model(df, IMGDIR_PATH, feature=feature, kernel_size=(constants["KERNEL_SIZE"], constants["KERNEL_SIZE"]))
     # model.load()
     # model.print_dataset_info()
@@ -34,4 +36,4 @@ if __name__ == "__main__":
     model.split_dataset()
     model.fit(constants["NUM_EPOCHS"])
     model.save()
-    # model.evaluate_and_show_predictions(num_samples=3)
+    model.evaluate_and_show_predictions(num_samples=3)

--- a/core/util/util.py
+++ b/core/util/util.py
@@ -33,6 +33,7 @@ class ConstantSingleton(object):
                 "LEARNING_RATE": self.args.LEARNING_RATE,
                 "NUM_EPOCHS": self.args.NUM_EPOCHS,
                 "NUM_IMAGES": self.args.NUM_IMAGES,
+                "NUM_SPECIES": self.args.NUM_SPECIES,
                 "IMG_SIZE": self.args.IMG_SIZE,
                 "CROPPED": self.args.CROPPED
             }
@@ -58,6 +59,8 @@ class ConstantSingleton(object):
                             help='an integer for amount of epochs')
         parser.add_argument('NUM_IMAGES', metavar='ImageAmount', type=int,
                             help='an integer for amount of images')
+        parser.add_argument('NUM_SPECIES', metavar='SpeciesAmount', type=int,
+                            help='an integer for amount of species')
         parser.add_argument('IMG_SIZE', metavar='ImageSize', type=int,
                             help='an integer N for size of images N x N')
         parser.add_argument('CROPPED', metavar='Cropped', type=int,

--- a/core/yolo/yolo_func.py
+++ b/core/yolo/yolo_func.py
@@ -31,5 +31,4 @@ def load_img(img, xywhn) -> Tuple[float, float, float, float]:
 def yolo_crop(img: Image.Image, xywhn, rs_size=(416, 416)):
     corners = load_img(img, xywhn)
     img1 = img.crop(corners)
-    img1 = img1.resize(rs_size, resample=3)
     return img1

--- a/core/yolo/yolo_func.py
+++ b/core/yolo/yolo_func.py
@@ -5,8 +5,9 @@ from PIL import Image
 Image.MAX_IMAGE_PIXELS = None
 
 
-def obj_det(img, model: YOLO, conf=0.25, img_size=(640, 640)):
-    res = model.predict(source=img, save=False, save_txt=False, imgsz=img_size, conf=conf, device="cpu")
+def obj_det(img, model: YOLO, conf=0.25, img_size=(640, 640), verbose=False):
+    res = model.predict(source=img, save=False, save_txt=False,
+                        imgsz=img_size, conf=conf, device="cpu", verbose=verbose)
     return res
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ scikit-learn==1.3.2
 keras==2.13.1
 psutil==5.9.6
 urllib3==2.0.7
+tqdm==4.66.1


### PR DESCRIPTION
To ensure less bias and that all species have the same amount of images for training, instead of creating training set based on rows in dataset, do it by first n species then group these and take the first x images. 

Also no more deleting image folder/csv file when changing parameters (except cropping).
leopidotera-dk.csv now includes all previously merged rows, instead of just our "working window" based on args. We can always infer how much we want based on args, but yolo results take quite a while to calculate, so these are now saved for later use. 

If cropping is not set, will just resize the original image, which interferes with if cropping is set. Will have workaround in future.

depends on #102 